### PR TITLE
Add a trace ID search box to the start page

### DIFF
--- a/app/assets/_platforms.sass
+++ b/app/assets/_platforms.sass
@@ -1,5 +1,16 @@
 @import 'panel'
 
+.tracesearch
+  display: flex
+  margin: 20px 0
+
+  input, button
+    height: 40px
+    font-size: 20px
+
+  input
+    flex-grow: 1
+
 .platforms
   .platform
     @extend %panel

--- a/app/views/platforms/index.html.slim
+++ b/app/views/platforms/index.html.slim
@@ -1,4 +1,8 @@
 .container
+  form.tracesearch action=search_path
+    input type="search" name="id" placeholder="Paste a trace ID here..."
+    button type="submit" Go
+
   .platforms
     - @platforms.each do |platform|
       .platform

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 Rails.application.routes.draw do
+  get '/t', to: 'root#trace', as: 'search'
   get '/t/:id', to: 'root#trace', as: 't'
   get '/platform/:id', to: 'platforms#show', as: 'platform'
 


### PR DESCRIPTION
**Fixes #3**

In combination with trace IDs on error pages, this should make debugging user reports easier. Let me know what you think about the implementation.

Screenshot:

![screenshot from 2018-10-29 17-43-51](https://user-images.githubusercontent.com/249125/47665806-485c6600-dba2-11e8-81af-b63623ef0ab4.png)
