### PR TITLE
Fix parsing of ISO8601 durations

### DIFF
--- a/app/controllers/concerns/controller/range.rb
+++ b/app/controllers/concerns/controller/range.rb
@@ -11,7 +11,7 @@ module Concerns
 
           if (value = try_to_i(param))
             value = value.minutes
-          elsif (value = try_to_duration("PT#{param}"))
+          elsif (value = try_to_duration(param))
             # noop
           else
             value = 6.hours


### PR DESCRIPTION
Apparently, durations are meant to be limited to time-based durations (because the "P" part is empty) - however, the "PT" prefix was applied twice.